### PR TITLE
Refactor AirfieldsController and update Airfield data

### DIFF
--- a/WrightBrothersApi/WrightBrothersApi/Controllers/AirfieldsController.cs
+++ b/WrightBrothersApi/WrightBrothersApi/Controllers/AirfieldsController.cs
@@ -1,19 +1,19 @@
 using Microsoft.AspNetCore.Mvc;
-using System.Collections.Generic;
 using WrightBrothersApi.Models;
+using System.Collections.Generic;
 
 namespace WrightBrothersApi.Controllers
 {
     [ApiController]
     [Route("[controller]")]
-    public class WrightBrothersAirfieldsController : ControllerBase
+    public class AirfieldsController : ControllerBase
     {
         private static readonly List<Airfield> Airfields = new List<Airfield>
         {
-            new Airfield("Huffman Prairie", "Dayton, Ohio", "1904-1905", "Second field used by the Wright Brothers"),
-            new Airfield("Kill Devil Hills", "Kitty Hawk, North Carolina", "1900-1903", "First field used by the Wright Brothers"),
-            new Airfield("Simms Station", "Dayton, Ohio", "1905-1909", "Third field used by the Wright Brothers"),
-            new Airfield("Wright Brothers Field", "Dayton, Ohio", "1910-1915", "Fourth field used by the Wright Brothers")
+            new Airfield("Huffman Prairie", "Dayton, Ohio", "1904-1905", "First practical airplane flights"),
+            new Airfield("Simms Station", "Dayton, Ohio", "1905-1909", "First civilian flight training school"),
+            new Airfield("Kill Devil Hills", "North Carolina", "1900-1903", "First controlled, sustained flight of a powered, heavier-than-air aircraft"),
+            new Airfield("Pau", "France", "1909", "First public passenger flights")
         };
 
         [HttpGet]
@@ -48,7 +48,6 @@ namespace WrightBrothersApi.Controllers
             {
                 return NotFound();
             }
-            airfield.Name = updatedAirfield.Name; // Fix: Make the 'Name' property accessible by adding a public set accessor in the 'Airfield' class.
             airfield.Location = updatedAirfield.Location;
             airfield.DatesOfUse = updatedAirfield.DatesOfUse;
             airfield.Significance = updatedAirfield.Significance;


### PR DESCRIPTION
This pull request primarily focuses on updates to the `AirfieldsController.cs` file in the `WrightBrothersApi` project. The changes include renaming the controller, updating the list of airfields and their descriptions, and removing the line of code that updates the `Name` property of an `Airfield` object in the `Update` method.

Here are the key changes:

* [`WrightBrothersApi/WrightBrothersApi/Controllers/AirfieldsController.cs`](diffhunk://#diff-c1923d29cb4041f319b97eab2cb7c1d9c14edeb5462fe9ac15835d7af8f21903L2-R16): The controller name has been changed from `WrightBrothersAirfieldsController` to `AirfieldsController`. This makes the name more concise and easier to understand.

* [`WrightBrothersApi/WrightBrothersApi/Controllers/AirfieldsController.cs`](diffhunk://#diff-c1923d29cb4041f319b97eab2cb7c1d9c14edeb5462fe9ac15835d7af8f21903L2-R16): The list of `Airfield` objects has been updated. The descriptions for each airfield have been changed to reflect significant events related to aviation history. This provides more accurate and informative details about each airfield.

* `WrightBrothersApi/WrightBrothersApi/Controllers/AirfieldsController.cs` (in `public ActionResult Update(string name, Airfield updatedAirfield)`): The line of code that updates the `Name` property of an `Airfield` object has been removed. This suggests that the `Name` property should not be updated once an `Airfield` object is created, maintaining the integrity of the object.